### PR TITLE
Introducing a new prop to allow multi-selection with metaKey

### DIFF
--- a/demo/dark-theme.html
+++ b/demo/dark-theme.html
@@ -27,6 +27,8 @@
       <sl-vue-tree
           v-model="nodes"
           ref="slVueTree"
+          multi-select-key="metaKey"
+          :allow-multiselect="true"
           @select="nodeSelected"
           @drop="nodeDropped"
           @toggle="nodeToggled"

--- a/src/sl-vue-tree.js
+++ b/src/sl-vue-tree.js
@@ -234,7 +234,7 @@ export default {
     },
 
     select(path, addToSelection = false, event = null) {
-      addToSelection = ((event && event[this.multiSelectKey]) || addToSelection) && this.allowMultiselect
+      addToSelection = ((event && event[this.multiSelectKey]) || addToSelection) && this.allowMultiselect;
       const selectedNode = this.getNode(path);
       if (!selectedNode) return null;
       const newNodes = this.copy(this.currentValue);

--- a/src/sl-vue-tree.js
+++ b/src/sl-vue-tree.js
@@ -234,13 +234,13 @@ export default {
     },
 
     select(path, addToSelection = false, event = null) {
+      addToSelection = ((event && event[this.multiSelectKey]) || addToSelection) && this.allowMultiselect
       const selectedNode = this.getNode(path);
       if (!selectedNode) return null;
       const newNodes = this.copy(this.currentValue);
       const shiftSelectionMode = this.allowMultiselect && event && event.shiftKey && this.lastSelectedNode;
       const selectedNodes = [];
       let shiftSelectionStarted = false;
-      addToSelection = ((event && event[this.multiSelectKey]) || addToSelection) && this.allowMultiselect
 
       this.traverse((node, nodeModel) => {
 

--- a/src/sl-vue-tree.js
+++ b/src/sl-vue-tree.js
@@ -25,11 +25,14 @@ export default {
       type: Boolean,
       default: true
     },
-    multiSelectKey: {
-      type: String,
-      default: 'ctrlKey',
+    multiselectKey: {
+      type: [String, Array],
+      default: ['ctrlKey', 'metaKey'],
       validator: function (value) {
-        return ['ctrlKey', 'metaKey', 'altKey'].indexOf(value) !== -1
+        let allowedKeys = ['ctrlKey', 'metaKey', 'altKey'];
+        let multiselectKeys = Array.isArray(value) ? value : [value];
+        multiselectKeys = multiselectKeys.filter(keyName => allowedKeys.indexOf(keyName ) !== -1);
+        return !!multiselectKeys.length;
       }
     },
     scrollAreaHeight: {
@@ -234,7 +237,12 @@ export default {
     },
 
     select(path, addToSelection = false, event = null) {
-      addToSelection = ((event && event[this.multiSelectKey]) || addToSelection) && this.allowMultiselect;
+      const multiselectKeys = Array.isArray(this.multiSelectKey) ?
+        this.multiselectKey:
+        [this.multiselectKey];
+      const multiselectKeyIsPressed = event && !!multiselectKeys.find(key => event[key]);
+      addToSelection = (multiselectKeyIsPressed || addToSelection) && this.allowMultiselect ;
+
       const selectedNode = this.getNode(path);
       if (!selectedNode) return null;
       const newNodes = this.copy(this.currentValue);

--- a/src/sl-vue-tree.js
+++ b/src/sl-vue-tree.js
@@ -25,6 +25,13 @@ export default {
       type: Boolean,
       default: true
     },
+    multiSelectKey: {
+      type: String,
+      default: 'ctrlKey',
+      validator: function (value) {
+        return ['ctrlKey', 'metaKey', 'altKey'].indexOf(value) !== -1
+      }
+    },
     scrollAreaHeight: {
       type: Number,
       default: 70
@@ -227,13 +234,13 @@ export default {
     },
 
     select(path, addToSelection = false, event = null) {
-      addToSelection = ((event && event.ctrlKey) || addToSelection) && this.allowMultiselect;
       const selectedNode = this.getNode(path);
       if (!selectedNode) return null;
       const newNodes = this.copy(this.currentValue);
       const shiftSelectionMode = this.allowMultiselect && event && event.shiftKey && this.lastSelectedNode;
       const selectedNodes = [];
       let shiftSelectionStarted = false;
+      addToSelection = ((event && event[this.multiSelectKey]) || addToSelection) && this.allowMultiselect
 
       this.traverse((node, nodeModel) => {
 


### PR DESCRIPTION
Hi, 

After playing hours (if not days) with vue ports of Draggable.js and Sortable.js, your project came as a lifebuoy...

However, I needed to be able to select multiple nodes but not with the Control Key (which triggers the opening of a right-click menu, and discard the selection event itself!).

I though a new prop would be useful, so here it is. 

Sorry for the multiple commits (my IDE screwed complegtely the existing code style, and while disantengling the diffs, it came as multiple commits).