### PR TITLE
add 'empty-node' slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,13 @@ interface ICursorPosition<TDataType> {
 # Slots
 
 
-| slot     | context     | description                                                                                   |
-|----------|-------------|-----------------------------------------------------------------------------------------------|
-| title    | ISlTreeNode | Slot for item title                                                                           |
-| toggle   | ISlTreeNode | Slot for expand/collapse button                                                               |
-| sidebar  | ISlTreeNode | Sidebar content                                                                               |
-| draginfo | SlVueTree   | Slot that follows the mouse cursor while dragging. By default shows the dragging nodes count. |
+| slot       | context     | description                                                                                   |
+|------------|-------------|-----------------------------------------------------------------------------------------------|
+| title      | ISlTreeNode | Slot for item title                                                                           |
+| toggle     | ISlTreeNode | Slot for expand/collapse button                                                               |
+| sidebar    | ISlTreeNode | Sidebar content                                                                               |
+| draginfo   | SlVueTree   | Slot that follows the mouse cursor while dragging. By default shows the dragging nodes count. |
+| node-empty | ISlTreeNode | Slot for (optional) message when folder is open, but empty                                    |
 
 
 ## Example:

--- a/src/sl-vue-tree.vue
+++ b/src/sl-vue-tree.vue
@@ -71,6 +71,11 @@
           </span>
 
             <slot name="title" :node="node">{{ node.title }}</slot>
+            
+            <slot name="empty-node" :node="node" v-if="!node.isLeaf && node.children.length == 0 && node.isExpanded">
+              <div> empty </div>
+            </slot>
+
           </div>
 
           <div class="sl-vue-tree-sidebar">

--- a/src/sl-vue-tree.vue
+++ b/src/sl-vue-tree.vue
@@ -73,7 +73,6 @@
             <slot name="title" :node="node">{{ node.title }}</slot>
             
             <slot name="empty-node" :node="node" v-if="!node.isLeaf && node.children.length == 0 && node.isExpanded">
-              <div> empty </div>
             </slot>
 
           </div>

--- a/src/sl-vue-tree.vue
+++ b/src/sl-vue-tree.vue
@@ -108,6 +108,11 @@
           <template slot="sidebar" slot-scope="{ node }">
             <slot name="sidebar" :node="node"></slot>
           </template>
+          
+          <template slot="empty-node" slot-scope="{ node }">
+            <slot name="empty-node" :node="node" v-if="!node.isLeaf && node.children.length == 0 && node.isExpanded">
+            </slot>
+          </template>
 
         </sl-vue-tree>
 


### PR DESCRIPTION
to show a message when a folder (= node that is !isLeaf) is expanded and has no children