### PR TITLE
Add sample of 'draginfo' slot

### DIFF
--- a/demo/dark-theme.html
+++ b/demo/dark-theme.html
@@ -59,6 +59,11 @@
           </span>
         </template>
 
+
+        <template slot="draginfo">
+          {{selectedNodesTitle}}
+        </template>
+
       </sl-vue-tree>
     </div>
 
@@ -114,7 +119,8 @@
      return {
        nodes: nodes,
        contextMenuIsVisible: false,
-       lastEvent: 'No last event'
+       lastEvent: 'No last event',
+       selectedNodesTitle: '',
      }
     },
 
@@ -134,7 +140,8 @@
       },
 
       nodeSelected(nodes, event) {
-        this.lastEvent = `Select nodes: ${nodes.map(node => node.title).join(', ')}`;
+        this.selectedNodesTitle = nodes.map(node => node.title).join(', ');
+        this.lastEvent = `Select nodes: ${this.selectedNodesTitle}`;
       },
 
       nodeToggled(node, event) {


### PR DESCRIPTION
Hi there,

While dragging a mouse cursor, I wanted to show title of node instead of `selectionSize` (default).
However, I could not find a sample of 'draginfo' slot.

I thought it might be useful for everybody if there is an example so I added the case.
What do you think?
