### PR TITLE
Inserting nodes to dropping position

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ interface ICursorPosition<TDataType> {
 | select(path: number[], addToSelection = false)                                                           | Select the node by using its path                                                                 |                                                                                                                                              |
 | getNodeEl(): HTMLElement                                                                                 | Get the node HTMLElement by using its path                                                        |
 | getSelected(): ISlTreeNode[]                                                                             | Get selected nodes                                                                                 |
+| insert(position: ICursorPosition, nodeModel: ISlTreeNodeModel)                                           | Insert nodes by the current cursor position.                                                       |
 | remove(paths: number[][])                                                                                | Remove nodes by paths. For example `.remove([[0,1], [0,2]])`
 | getFirstNode(): ISlTreeNode                                                                              | Get the first node in the tree                                                                     |
 | getLastNode(): ISlTreeNode                                                                               | Get the last node in the tree

--- a/demo/externaldrag.html
+++ b/demo/externaldrag.html
@@ -111,6 +111,7 @@
     methods: {
 
       onExternalDropHandler(cursorPosition, event) {
+        this.$refs.slVueTree.insert(cursorPosition, {title: "Dragged Item", isLeaf: true});
         console.log('external drop', cursorPosition);
       }
 

--- a/src/sl-vue-tree.js
+++ b/src/sl-vue-tree.js
@@ -589,21 +589,7 @@ export default {
       }
 
       // insert dragging nodes to the new place
-      const destNode = this.cursorPosition.node;
-      const destSiblings = this.getNodeSiblings(newNodes, destNode.path);
-      const destNodeModel = destSiblings[destNode.ind];
-
-      if (this.cursorPosition.placement === 'inside') {
-        destNodeModel.children = destNodeModel.children || [];
-        destNodeModel.children.unshift(...nodeModelsToInsert);
-      } else {
-        const insertInd = this.cursorPosition.placement === 'before' ?
-          destNode.ind :
-          destNode.ind + 1;
-
-        destSiblings.splice(insertInd, 0, ...nodeModelsToInsert);
-      }
-
+      this.insertModels(this.cursorPosition, nodeModelsToInsert, newNodes);
 
 
       // delete dragging node from the old place
@@ -736,6 +722,32 @@ export default {
         if (!nodeModel._markToDelete) return;
         siblings.splice(ind, 1);
       }, newNodes);
+
+      this.emitInput(newNodes);
+    },
+
+    insertModels(cursorPosition, nodeModels, newNodes) {
+      const destNode = cursorPosition.node;
+      const destSiblings = this.getNodeSiblings(newNodes, destNode.path);
+      const destNodeModel = destSiblings[destNode.ind];
+
+      if (cursorPosition.placement === 'inside') {
+        destNodeModel.children = destNodeModel.children || [];
+        destNodeModel.children.unshift(...nodeModels);
+      } else {
+        const insertInd = cursorPosition.placement === 'before' ?
+          destNode.ind :
+          destNode.ind + 1;
+
+        destSiblings.splice(insertInd, 0, ...nodeModels);
+      }
+    },
+
+    insert(cursorPosition, nodeModel) {
+      const nodeModels = Array.isArray(nodeModel) ? nodeModel : [nodeModel];
+      const newNodes = this.copy(this.currentValue);
+
+      this.insertModels(cursorPosition, nodeModels, newNodes);
 
       this.emitInput(newNodes);
     },


### PR DESCRIPTION
Hi.

When `externaldrop` event happens, I want to insert targeted nodes to dropping position.
It seems that `onNodeMouseupHandler` can be used for the same purposes, I carved out its logic.

We also added examples of use in the demo, Please have a look at them.